### PR TITLE
Update logger to handle PIM fatal error responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+php: 7.2
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+install:
+    - composer install
+
+script:
+    - ./vendor/bin/phpspec run

--- a/src/FileLogger.php
+++ b/src/FileLogger.php
@@ -83,7 +83,6 @@ class FileLogger
                     } else {
                         $this->skip(json_encode($response));
                     }
-
             }
         }
     }

--- a/src/FileLogger.php
+++ b/src/FileLogger.php
@@ -72,9 +72,18 @@ class FileLogger
                     $this->numUpdated++;
                     break;
                 default:
-                    $this->skip(
-                        sprintf('Skipped record "%s", an error occured during import: %s', $response['code'], json_encode($response['errors']))
-                    );
+                    if (isset($response['code']) && isset($response['errors'])) {
+                        $this->skip(
+                            sprintf(
+                                'Skipped record "%s", an error occured during import: %s',
+                                $response['code'],
+                                json_encode($response['errors'])
+                            )
+                        );
+                    } else {
+                        $this->skip(json_encode($response));
+                    }
+
             }
         }
     }


### PR DESCRIPTION
In rare cases, the PIM `$response` doesn't contain an `errors` key.
So in this case, we simply log the whole response.